### PR TITLE
clear the maxWait timeout event when setWait calls finalize

### DIFF
--- a/lib/cloudservers/server.js
+++ b/lib/cloudservers/server.js
@@ -481,11 +481,12 @@ Server.prototype = {
                 }
                 else if (calledBack) {
                     clearInterval(equalCheckId);
+                    clearTimeout(equalTimeoutId);
                 }
             });
         }, options.interval);
 
-        setTimeout(function() {
+        var equalTimeoutId = setTimeout(function() {
             if (!calledBack) {
                 finalize({ error: 'Max timeout exceeded' });
             }
@@ -494,6 +495,7 @@ Server.prototype = {
         function finalize(err) {
             calledBack = true;
             clearInterval(equalCheckId);
+            clearTimeout(equalTimeoutId);
             if (options.finish) {
                 options.finish();
             }


### PR DESCRIPTION
this was causing my app to hang and not terminate. i was just building a few servers and then waiting until they finished, and wanted to just exit after that. this patch solved it for me.
