### PR TITLE
setWait for a value to not be equal to something

### DIFF
--- a/lib/cloudservers/server.js
+++ b/lib/cloudservers/server.js
@@ -451,13 +451,13 @@ Server.prototype = {
      * results against the attributes parameter. When the attributes match
      * the callback will be fired.
      *
-     * @param {Object}      attributes  the value to check for during the interval
-     * @param {Object}     options      valid keys:
-     *                                    interval (int in miliseconds)
-     *                                    maxWait (int in seconds)
-     *                                    update (function)
-     *                                    finish (function)
-     *                                    checkStatus (function)
+     * @param {Object}     attributes   the value to check for during the interval
+     * @param {Number}     options.interval    polling period in miliseconds
+     * @param {Number}     options.maxWait     max time to wait in seconds
+     * @param {Function}   options.update      called after each poll of the server
+     * @param {Function}   options.finish      called when the wait is over (no args)
+     * @param {Function}   options.checkStatus called should return true or false to 
+     * see if the server is ready.  passed the server object as an argument.
      * @param {Function}    callback    handles the callback of your api call
      */
     setWait: function(attributes, options, callback) {

--- a/lib/cloudservers/server.js
+++ b/lib/cloudservers/server.js
@@ -452,7 +452,12 @@ Server.prototype = {
      * the callback will be fired.
      *
      * @param {Object}      attributes  the value to check for during the interval
-     * @param {Object}     options      interval options including max wait in minutes
+     * @param {Object}     options      valid keys:
+     *                                    interval (int in miliseconds)
+     *                                    maxWait (int in seconds)
+     *                                    update (function)
+     *                                    finish (function)
+     *                                    checkStatus (function)
      * @param {Function}    callback    handles the callback of your api call
      */
     setWait: function(attributes, options, callback) {
@@ -470,11 +475,14 @@ Server.prototype = {
                 
                 var equal = true, keys = Object.keys(attributes);
                 for (var index in keys) {
-                    if (attributes[keys[index]] !== server[keys[index]] &&
-                          attributes[keys[index]].$ne === server[keys[index]]) {
+                    if (attributes[keys[index]] !== server[keys[index]]) {
                         equal = false;
                         break;
                     }
+                }
+
+                if (options.checkStatus) {
+                    equal = options.checkStatus(server);
                 }
 
                 if (equal && !calledBack) {

--- a/lib/cloudservers/server.js
+++ b/lib/cloudservers/server.js
@@ -470,7 +470,8 @@ Server.prototype = {
                 
                 var equal = true, keys = Object.keys(attributes);
                 for (var index in keys) {
-                    if (attributes[keys[index]] !== server[keys[index]]) {
+                    if (attributes[keys[index]] !== server[keys[index]] &&
+                          attributes[keys[index]].$ne === server[keys[index]]) {
                         equal = false;
                         break;
                     }

--- a/lib/cloudservers/server.js
+++ b/lib/cloudservers/server.js
@@ -457,7 +457,6 @@ Server.prototype = {
      * @param {Number}     options.maxWait     max time to wait in seconds
      * @param {Function}   options.update      called after each poll of the server
      * @param {Function}   options.finish      called when the wait is over (no args)
-     * @param {Function}   options.checkStatus called should return true or false to 
      * see if the server is ready.  passed the server object as an argument.
      * @param {Function}    callback    handles the callback of your api call
      */
@@ -490,7 +489,7 @@ Server.prototype = {
                     }
                 }
                 else if (checkStatus) {
-                    equal = options.checkStatus(server);
+                    equal = checkStatus(server);
                 }
 
                 if (equal && !calledBack) {

--- a/lib/cloudservers/server.js
+++ b/lib/cloudservers/server.js
@@ -451,7 +451,8 @@ Server.prototype = {
      * results against the attributes parameter. When the attributes match
      * the callback will be fired.
      *
-     * @param {Object}     attributes   the value to check for during the interval
+     * @param {Object|Function}   attributes   the value to check for during the interval.
+     * can also be a function that returns a true or false value to indicate a match.
      * @param {Number}     options.interval    polling period in miliseconds
      * @param {Number}     options.maxWait     max time to wait in seconds
      * @param {Function}   options.update      called after each poll of the server
@@ -462,7 +463,13 @@ Server.prototype = {
      */
     setWait: function(attributes, options, callback) {
         var self = this,
-            calledBack = false;
+            calledBack = false,
+            checkStatus = false;
+
+        if ((typeof attributes) === 'function') {
+            checkStatus = attributes;
+            attributes = false;
+        }
 
         var equalCheckId = setInterval(function() {
 
@@ -472,16 +479,17 @@ Server.prototype = {
                 if (options.update) {
                     options.update();
                 }
-
-                var equal = true, keys = Object.keys(attributes);
-                for (var index in keys) {
-                    if (attributes[keys[index]] !== server[keys[index]]) {
-                        equal = false;
-                        break;
+                
+                if (attributes) {
+                    var equal = true, keys = Object.keys(attributes);
+                    for (var index in keys) {
+                        if (attributes[keys[index]] !== server[keys[index]]) {
+                            equal = false;
+                            break;
+                        }
                     }
                 }
-
-                if (options.checkStatus) {
+                else if (checkStatus) {
                     equal = options.checkStatus(server);
                 }
 


### PR DESCRIPTION
I needed a way to build a server and wait until it was both active, and it had the accessIPv4 fields populated.  using setWait would return when it was active, but in about 70% of cases, the accessIPv4 field was not populated for until another couple of seconds.  my choices were to either implement my own polling system that could do this, or this small patch to enable it in rackspace-openstack.  this seemed cleaner.

---

this enables an attribute to be provided to Server.setWait and it will wait until it is not equal to the associated value.  example:

```
server.setWait(
  { status:'ACTIVE', accessIPv4:{$ne:''} },
  { interval:2000 },
  function(err, server) {
    // We now know that the server is active and that
    // the accessIPv4 property has been populated.
  }
);
```
