### PR TITLE
return an error in LoadBalancer.setErrorPage

### DIFF
--- a/lib/cloudloadbalancers/loadbalancer.js
+++ b/lib/cloudloadbalancers/loadbalancer.js
@@ -921,7 +921,7 @@ LoadBalancer.prototype = {
 
         self.client.authorizedRequest(requestOptions, function(err, res, body) {
             if (err || !body.errorpage) {
-                callback(err);
+                callback(err ? err : body);
                 return;
             }
 


### PR DESCRIPTION
was just hacking around with load balancers and I couldn't figure out why things weren't working even through my application didn't get any errors.  eventually figured out this was why.
