### PR TITLE
expect 202 response in LoadBalancer.setErrorPage

### DIFF
--- a/lib/cloudloadbalancers/loadbalancer.js
+++ b/lib/cloudloadbalancers/loadbalancer.js
@@ -920,12 +920,12 @@ LoadBalancer.prototype = {
             };
 
         self.client.authorizedRequest(requestOptions, function(err, res, body) {
-            if (err || !body.errorpage) {
+            if (err || res.statusCode !== 202) {
                 callback(err);
                 return;
             }
 
-            callback(err, body.errorpage);
+            callback(err, (body && body.errorpage) ? body.errorpage : true);
         });
     },
 


### PR DESCRIPTION
i see that the official docs say that this should return a 200 with a body, but that's not what i've been seeing.  without this patch, my application crashes when setErrorPage is called.  i think this patch could be better, so if you have any suggestions, please let me know and i will fix it.
